### PR TITLE
Make it rebar3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.o
 *.beam
 *.so
+*.d
 .eunit/
 ebin/
 priv/
 deps/
+_build/
+rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -6,3 +6,12 @@
 {deps, [
 	{proper, ".*", {git, "https://github.com/manopapad/proper.git", "master"}}
 ]}.
+
+{plugins, [pc]}.
+
+{provider_hooks,
+    [{pre, [
+        {compile, {pc, compile}},
+        {clean, {pc, clean}}
+    ]}
+]}.


### PR DESCRIPTION
#### Problem description
Library is not compatible with `rebar3`

#### Solution description
Added `pc` plugin to make it compatible and added `rebar3` related files to `.gitignore`